### PR TITLE
Add cricket score extension skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # Testing1
+
+This repository contains a sample Chrome extension that displays live cricket scores with YouTube highlight recommendations.
+
+## Extension Setup
+
+1. Get API keys:
+   - **Cricket API**: Sign up at [cricapi.com](https://www.cricapi.com/) and obtain an API key.
+   - **YouTube Data API**: Create a project on [Google Cloud](https://console.cloud.google.com/) and generate an API key for the YouTube Data API v3.
+2. Replace the placeholders `YOUR_CRIC_API_KEY` and `YOUR_YOUTUBE_API_KEY` in `cricket-extension/popup.js` with your keys.
+3. Open Chrome and navigate to `chrome://extensions`.
+4. Enable **Developer mode** and choose **Load unpacked**.
+5. Select the `cricket-extension` folder to install the extension.
+6. Click the extension icon to view live scores and video highlights.
+
+The code is provided under the MIT License located in `LICENSE`.

--- a/cricket-extension/background.js
+++ b/cricket-extension/background.js
@@ -1,0 +1,17 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create('updateScores', { periodInMinutes: 5 });
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === 'updateScores') {
+    chrome.action.setBadgeText({ text: '...' });
+    fetch(`https://api.cricapi.com/v1/currentMatches?apikey=YOUR_CRIC_API_KEY`)
+      .then(resp => resp.json())
+      .then(() => {
+        chrome.action.setBadgeText({ text: '' });
+      })
+      .catch(() => {
+        chrome.action.setBadgeText({ text: '!' });
+      });
+  }
+});

--- a/cricket-extension/manifest.json
+++ b/cricket-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Live Cricket Scores",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "Show live cricket scores with recommended YouTube highlights.",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://api.cricapi.com/*",
+    "https://www.googleapis.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Cricket Scores"
+  }
+}

--- a/cricket-extension/popup.html
+++ b/cricket-extension/popup.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Cricket Scores</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; margin: 10px; }
+    #scores, #videos { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Live Scores</h1>
+  <div id="scores">Loading...</div>
+  <h2>Highlights</h2>
+  <ul id="videos"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/cricket-extension/popup.js
+++ b/cricket-extension/popup.js
@@ -1,0 +1,55 @@
+const CRIC_API_KEY = 'YOUR_CRIC_API_KEY';
+const YOUTUBE_API_KEY = 'YOUR_YOUTUBE_API_KEY';
+
+async function fetchScores() {
+  const url = `https://api.cricapi.com/v1/currentMatches?apikey=${CRIC_API_KEY}`;
+  try {
+    const resp = await fetch(url);
+    const data = await resp.json();
+    const scoresEl = document.getElementById('scores');
+    scoresEl.innerHTML = '';
+    if (data && data.data) {
+      data.data.slice(0, 5).forEach(match => {
+        const div = document.createElement('div');
+        div.textContent = `${match.name}: ${match.status}`;
+        scoresEl.appendChild(div);
+      });
+    } else {
+      scoresEl.textContent = 'No data';
+    }
+  } catch (err) {
+    console.error(err);
+    document.getElementById('scores').textContent = 'Error fetching scores';
+  }
+}
+
+async function fetchHighlights() {
+  const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&q=cricket%20highlights&type=video&maxResults=5&key=${YOUTUBE_API_KEY}`;
+  try {
+    const resp = await fetch(url);
+    const data = await resp.json();
+    const videosEl = document.getElementById('videos');
+    videosEl.innerHTML = '';
+    if (data && data.items) {
+      data.items.forEach(item => {
+        const li = document.createElement('li');
+        const a = document.createElement('a');
+        a.href = `https://www.youtube.com/watch?v=${item.id.videoId}`;
+        a.textContent = item.snippet.title;
+        a.target = '_blank';
+        li.appendChild(a);
+        videosEl.appendChild(li);
+      });
+    } else {
+      videosEl.textContent = 'No highlights found';
+    }
+  } catch (err) {
+    console.error(err);
+    document.getElementById('videos').textContent = 'Error fetching highlights';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  fetchScores();
+  fetchHighlights();
+});


### PR DESCRIPTION
## Summary
- add Chrome extension that fetches cricket scores and YouTube highlights
- update README with installation instructions

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_685fdf955a28832d9f666f2ab55113c2