### PR TITLE
Add NBA playoff extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,15 @@ This repository contains a sample Chrome extension that displays live cricket sc
 6. Click the extension icon to view live scores and video highlights.
 
 The code is provided under the MIT License located in `LICENSE`.
+
+## NBA Playoff Tracker Extension
+
+This repository also includes a Chrome extension that shows the latest NBA playoff game information. The extension fetches the most recent postseason matchup, displays a short summary, top YouTube highlights and leading scorers.
+
+### Setup
+1. Obtain a YouTube Data API v3 key.
+2. Replace `YOUR_YOUTUBE_API_KEY` in `nba-extension/popup.js` with your key.
+3. Open Chrome and navigate to `chrome://extensions`.
+4. Enable **Developer mode** and select **Load unpacked**.
+5. Choose the `nba-extension` folder.
+6. Click the extension icon to view game details.

--- a/nba-extension/background.js
+++ b/nba-extension/background.js
@@ -1,0 +1,17 @@
+chrome.runtime.onInstalled.addListener(() => {
+  chrome.alarms.create('updateNBA', { periodInMinutes: 10 });
+});
+
+chrome.alarms.onAlarm.addListener((alarm) => {
+  if (alarm.name === 'updateNBA') {
+    chrome.action.setBadgeText({ text: '...' });
+    fetch('https://www.balldontlie.io/api/v1/games?per_page=1')
+      .then(resp => resp.json())
+      .then(() => {
+        chrome.action.setBadgeText({ text: '' });
+      })
+      .catch(() => {
+        chrome.action.setBadgeText({ text: '!' });
+      });
+  }
+});

--- a/nba-extension/manifest.json
+++ b/nba-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "NBA Playoff Tracker",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "Show latest NBA playoff game details, top plays, highlights and team stats.",
+  "permissions": ["storage"],
+  "host_permissions": [
+    "https://www.balldontlie.io/*",
+    "https://www.googleapis.com/*"
+  ],
+  "background": {
+    "service_worker": "background.js"
+  },
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "NBA Playoff"
+  }
+}

--- a/nba-extension/popup.html
+++ b/nba-extension/popup.html
@@ -1,0 +1,22 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>NBA Playoffs</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 320px; margin: 10px; }
+    #game, #summary, #videos, #stats { margin-top: 10px; }
+  </style>
+</head>
+<body>
+  <h1>Latest Game</h1>
+  <div id="game">Loading...</div>
+  <h2>Summary</h2>
+  <div id="summary">Loading...</div>
+  <h2>Highlights</h2>
+  <ul id="videos"></ul>
+  <h2>Team Stats</h2>
+  <div id="stats">Loading...</div>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/nba-extension/popup.js
+++ b/nba-extension/popup.js
@@ -1,0 +1,93 @@
+async function fetchLatestGame() {
+  const resp = await fetch('https://www.balldontlie.io/api/v1/games?postseason=true&per_page=1');
+  const data = await resp.json();
+  return data.data && data.data.length ? data.data[0] : null;
+}
+
+async function fetchGameStats(gameId) {
+  const resp = await fetch(`https://www.balldontlie.io/api/v1/stats?game_ids[]=${gameId}&per_page=100`);
+  const data = await resp.json();
+  return data.data || [];
+}
+
+async function fetchHighlights(query) {
+  const url = `https://www.googleapis.com/youtube/v3/search?part=snippet&q=${encodeURIComponent(query)}&type=video&maxResults=5&key=YOUR_YOUTUBE_API_KEY`;
+  const resp = await fetch(url);
+  const data = await resp.json();
+  return data.items || [];
+}
+
+function summarizePlays(game, stats) {
+  if (!game) return 'No game data available.';
+  const homePoints = game.home_team_score;
+  const visitorPoints = game.visitor_team_score;
+  const winner = homePoints > visitorPoints ? game.home_team.full_name : game.visitor_team.full_name;
+  return `${winner} won ${homePoints}-${visitorPoints}.`;
+}
+
+function displayGame(game) {
+  const gameEl = document.getElementById('game');
+  if (!game) {
+    gameEl.textContent = 'No recent playoff games found.';
+    return;
+  }
+  gameEl.textContent = `${game.home_team.full_name} vs ${game.visitor_team.full_name} on ${game.date.slice(0,10)}`;
+}
+
+function displaySummary(summary) {
+  document.getElementById('summary').textContent = summary;
+}
+
+function displayStats(stats) {
+  const statsEl = document.getElementById('stats');
+  statsEl.innerHTML = '';
+  if (!stats.length) {
+    statsEl.textContent = 'No stats available.';
+    return;
+  }
+  const top = {};
+  stats.forEach(s => {
+    const team = s.team.full_name;
+    if (!top[team] || s.pts > top[team].pts) {
+      top[team] = { player: `${s.player.first_name} ${s.player.last_name}`, pts: s.pts };
+    }
+  });
+  Object.keys(top).forEach(team => {
+    const div = document.createElement('div');
+    div.textContent = `${team}: Top scorer ${top[team].player} with ${top[team].pts} pts`;
+    statsEl.appendChild(div);
+  });
+}
+
+function displayVideos(videos) {
+  const videosEl = document.getElementById('videos');
+  videosEl.innerHTML = '';
+  if (!videos.length) {
+    videosEl.textContent = 'No videos found.';
+    return;
+  }
+  videos.forEach(v => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = `https://www.youtube.com/watch?v=${v.id.videoId}`;
+    a.textContent = v.snippet.title;
+    a.target = '_blank';
+    li.appendChild(a);
+    videosEl.appendChild(li);
+  });
+}
+
+async function init() {
+  const game = await fetchLatestGame();
+  displayGame(game);
+  if (!game) return;
+  const stats = await fetchGameStats(game.id);
+  const summary = summarizePlays(game, stats);
+  displaySummary(summary);
+  displayStats(stats);
+  const query = `${game.home_team.full_name} vs ${game.visitor_team.full_name} playoffs highlights`;
+  const videos = await fetchHighlights(query);
+  displayVideos(videos);
+}
+
+document.addEventListener('DOMContentLoaded', init);


### PR DESCRIPTION
## Summary
- create `nba-extension` for latest NBA playoff data
- fetch game and stats from balldontlie API
- retrieve highlight videos from YouTube
- document new extension in README

## Testing
- `node -v`

------
https://chatgpt.com/codex/tasks/task_e_685fe993ebd0832d958d14324b9ce4e6