### PR TITLE
Add Clipboard QR extension

### DIFF
--- a/clipboard-qr-extension/manifest.json
+++ b/clipboard-qr-extension/manifest.json
@@ -1,0 +1,11 @@
+{
+  "name": "Clipboard QR Saver",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "Save clipboard text and generate a QR code for quick sharing.",
+  "permissions": ["storage", "clipboardRead", "clipboardWrite"],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Clipboard QR"
+  }
+}

--- a/clipboard-qr-extension/popup.html
+++ b/clipboard-qr-extension/popup.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Clipboard QR</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; margin: 10px; }
+    #qr { margin-top: 10px; width: 200px; height: 200px; }
+    #history { margin-top: 10px; padding: 0; list-style-type: none; }
+  </style>
+</head>
+<body>
+  <h1>Clipboard QR</h1>
+  <button id="saveBtn">Save Clipboard</button>
+  <div id="status"></div>
+  <img id="qr" src="" alt="QR code">
+  <h2>History</h2>
+  <ul id="history"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/clipboard-qr-extension/popup.js
+++ b/clipboard-qr-extension/popup.js
@@ -1,0 +1,47 @@
+function showQR(text) {
+  const img = document.getElementById('qr');
+  img.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(text)}`;
+}
+
+function updateHistory(history) {
+  const ul = document.getElementById('history');
+  ul.innerHTML = '';
+  history.slice(0, 5).forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    ul.appendChild(li);
+  });
+}
+
+async function saveClipboard() {
+  const status = document.getElementById('status');
+  try {
+    const text = await navigator.clipboard.readText();
+    if (!text) {
+      status.textContent = 'Clipboard is empty';
+      return;
+    }
+    chrome.storage.local.get({ history: [] }, data => {
+      const history = data.history;
+      history.unshift(text);
+      chrome.storage.local.set({ history }, () => {
+        status.textContent = 'Saved!';
+        showQR(text);
+        updateHistory(history);
+      });
+    });
+  } catch (e) {
+    console.error(e);
+    status.textContent = 'Failed to read clipboard';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  document.getElementById('saveBtn').addEventListener('click', saveClipboard);
+  chrome.storage.local.get({ history: [] }, data => {
+    updateHistory(data.history);
+    if (data.history.length) {
+      showQR(data.history[0]);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- add Chrome extension to save clipboard text and generate QR code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686030010488832db060c162475965ab