### PR TITLE
Add toggle for automatic clipboard saving

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,14 @@ This repository also includes a Chrome extension that shows the latest NBA playo
 4. Enable **Developer mode** and select **Load unpacked**.
 5. Choose the `nba-extension` folder. The extension requires the `alarms` permission for periodic updates.
 6. Click the extension icon to view game details.
+
+## Clipboard QR Saver
+
+This extension automatically saves text that you copy and provides a QR code for quick sharing.
+
+### Setup
+1. Open Chrome and go to `chrome://extensions`.
+2. Enable **Developer mode** and click **Load unpacked**.
+3. Select the `clipboard-qr-extension` folder.
+4. Copy any text using **Ctrl/Cmd+C**. Open the extension popup to view a QR code of your latest clipboard entry.
+5. Use the **Auto save on copy** toggle in the popup to enable or disable automatic saving. The feature is enabled by default.

--- a/clipboard-qr-extension/content.js
+++ b/clipboard-qr-extension/content.js
@@ -1,17 +1,13 @@
 // Automatically save clipboard text on copy
 // Listens for copy events and stores clipboard history
 
-document.addEventListener('copy', () => {
-  chrome.storage.local.get({ autoSave: true, history: [] }, async data => {
+document.addEventListener('copy', e => {
+  chrome.storage.local.get({ autoSave: true, history: [] }, data => {
     if (!data.autoSave) return;
-    try {
-      const text = await navigator.clipboard.readText();
-      if (!text) return;
-      const history = data.history;
-      history.unshift(text);
-      chrome.storage.local.set({ history });
-    } catch (err) {
-      console.error('Failed to read clipboard', err);
-    }
+    const text = e.clipboardData.getData('text/plain');
+    if (!text) return;
+    const history = data.history;
+    history.unshift(text);
+    chrome.storage.local.set({ history });
   });
 });

--- a/clipboard-qr-extension/content.js
+++ b/clipboard-qr-extension/content.js
@@ -1,0 +1,17 @@
+// Automatically save clipboard text on copy
+// Listens for copy events and stores clipboard history
+
+document.addEventListener('copy', () => {
+  chrome.storage.local.get({ autoSave: true, history: [] }, async data => {
+    if (!data.autoSave) return;
+    try {
+      const text = await navigator.clipboard.readText();
+      if (!text) return;
+      const history = data.history;
+      history.unshift(text);
+      chrome.storage.local.set({ history });
+    } catch (err) {
+      console.error('Failed to read clipboard', err);
+    }
+  });
+});

--- a/clipboard-qr-extension/manifest.json
+++ b/clipboard-qr-extension/manifest.json
@@ -1,0 +1,18 @@
+{
+  "name": "Clipboard QR Saver",
+  "version": "1.0",
+  "manifest_version": 3,
+  "description": "Save clipboard text and generate a QR code for quick sharing.",
+  "permissions": ["storage", "clipboardRead", "clipboardWrite"],
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content.js"],
+      "run_at": "document_start"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html",
+    "default_title": "Clipboard QR"
+  }
+}

--- a/clipboard-qr-extension/popup.html
+++ b/clipboard-qr-extension/popup.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Clipboard QR</title>
+  <style>
+    body { font-family: Arial, sans-serif; width: 300px; margin: 10px; }
+    #qr { margin-top: 10px; width: 200px; height: 200px; }
+    #history { margin-top: 10px; padding: 0; list-style-type: none; }
+  </style>
+</head>
+<body>
+  <h1>Clipboard QR</h1>
+  <button id="saveBtn">Save Clipboard</button>
+  <label>
+    <input type="checkbox" id="autoSaveToggle">
+    Auto save on copy
+  </label>
+  <div id="status"></div>
+  <img id="qr" src="" alt="QR code">
+  <h2>History</h2>
+  <ul id="history"></ul>
+  <script src="popup.js"></script>
+</body>
+</html>

--- a/clipboard-qr-extension/popup.js
+++ b/clipboard-qr-extension/popup.js
@@ -38,6 +38,7 @@ async function saveClipboard() {
 
 document.addEventListener('DOMContentLoaded', () => {
   const toggle = document.getElementById('autoSaveToggle');
+  const status = document.getElementById('status');
   document.getElementById('saveBtn').addEventListener('click', saveClipboard);
   chrome.storage.local.get({ history: [], autoSave: true }, data => {
     updateHistory(data.history);
@@ -48,6 +49,8 @@ document.addEventListener('DOMContentLoaded', () => {
   });
 
   toggle.addEventListener('change', () => {
-    chrome.storage.local.set({ autoSave: toggle.checked });
+    chrome.storage.local.set({ autoSave: toggle.checked }, () => {
+      status.textContent = toggle.checked ? 'Auto save enabled' : 'Auto save disabled';
+    });
   });
 });

--- a/clipboard-qr-extension/popup.js
+++ b/clipboard-qr-extension/popup.js
@@ -1,0 +1,53 @@
+function showQR(text) {
+  const img = document.getElementById('qr');
+  img.src = `https://api.qrserver.com/v1/create-qr-code/?size=200x200&data=${encodeURIComponent(text)}`;
+}
+
+function updateHistory(history) {
+  const ul = document.getElementById('history');
+  ul.innerHTML = '';
+  history.slice(0, 5).forEach(item => {
+    const li = document.createElement('li');
+    li.textContent = item;
+    ul.appendChild(li);
+  });
+}
+
+async function saveClipboard() {
+  const status = document.getElementById('status');
+  try {
+    const text = await navigator.clipboard.readText();
+    if (!text) {
+      status.textContent = 'Clipboard is empty';
+      return;
+    }
+    chrome.storage.local.get({ history: [] }, data => {
+      const history = data.history;
+      history.unshift(text);
+      chrome.storage.local.set({ history }, () => {
+        status.textContent = 'Saved!';
+        showQR(text);
+        updateHistory(history);
+      });
+    });
+  } catch (e) {
+    console.error(e);
+    status.textContent = 'Failed to read clipboard';
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const toggle = document.getElementById('autoSaveToggle');
+  document.getElementById('saveBtn').addEventListener('click', saveClipboard);
+  chrome.storage.local.get({ history: [], autoSave: true }, data => {
+    updateHistory(data.history);
+    if (data.history.length) {
+      showQR(data.history[0]);
+    }
+    toggle.checked = data.autoSave;
+  });
+
+  toggle.addEventListener('change', () => {
+    chrome.storage.local.set({ autoSave: toggle.checked });
+  });
+});


### PR DESCRIPTION
## Summary
- add auto-save toggle to popup
- respect toggle in copy listener
- document default auto-save setting

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686030010488832db060c162475965ab